### PR TITLE
Prevent mintCharacterNFTAction(index) on load

### DIFF
--- a/NFT_Game/en/Section_3/Lesson_5_Building_Character_Select_Page.md
+++ b/NFT_Game/en/Section_3/Lesson_5_Building_Character_Select_Page.md
@@ -138,7 +138,7 @@ const renderCharacters = () =>
       <button
         type="button"
         className="character-mint-button"
-        onClick={mintCharacterNFTAction(index)}
+        onClick={() => mintCharacterNFTAction(index)}
       >{`Mint ${character.name}`}</button>
     </div>
   ));


### PR DESCRIPTION
Changed to onClick={() => mintCharacterNFTAction(index)} to prevent mintCharacterNFTAction from getting called on load of the page. The error prevents the character select from loading. This is fixed later in the lesson, but this error initially prevents the student from seeing the character selection screen and getting visual feedback.